### PR TITLE
Update URL for bucklets submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "bucklets"]
 	path = bucklets
-	url = ../bucklets
+	url = https://gerrit.googlesource.com/bucklets


### PR DESCRIPTION
The google/bucklets repo doesn't exist on github, if it ever did, so the build instructions will fail at the `git submodule update --init` step. Pointing to what appears to be the canonical home at `https://gerrit.googlesource.com/bucklets` allows the submodule to be pulled in succesfully.