### PR TITLE
Add Sub Navbar Support To Gitiles

### DIFF
--- a/java/com/google/gitiles/doc/MarkdownConfig.java
+++ b/java/com/google/gitiles/doc/MarkdownConfig.java
@@ -50,6 +50,7 @@ public class MarkdownConfig {
   final boolean safeHtml;
   final boolean smartQuote;
   final boolean strikethrough;
+  final boolean subNavbar;
   final boolean tables;
   final boolean toc;
 
@@ -71,6 +72,7 @@ public class MarkdownConfig {
     safeHtml = cfg.getBoolean("markdown", "safehtml", githubFlavor);
     smartQuote = cfg.getBoolean("markdown", "smartquote", false);
     strikethrough = cfg.getBoolean("markdown", "strikethrough", githubFlavor);
+    subNavbar = cfg.getBoolean("markdown", "subnavbar", false);
     tables = cfg.getBoolean("markdown", "tables", githubFlavor);
     toc = cfg.getBoolean("markdown", "toc", true);
 
@@ -100,6 +102,7 @@ public class MarkdownConfig {
     safeHtml = on("safehtml", p.safeHtml, enable, disable);
     smartQuote = on("smartquote", p.smartQuote, enable, disable);
     strikethrough = on("strikethrough", p.strikethrough, enable, disable);
+    subNavbar = on("subnavbar", p.subNavbar, enable, disable);
     tables = on("tables", p.tables, enable, disable);
     toc = on("toc", p.toc, enable, disable);
 

--- a/javatests/com/google/gitiles/ServletTest.java
+++ b/javatests/com/google/gitiles/ServletTest.java
@@ -33,6 +33,7 @@ import org.eclipse.jgit.internal.storage.dfs.DfsRepositoryDescription;
 import org.eclipse.jgit.internal.storage.dfs.InMemoryRepository;
 import org.eclipse.jgit.junit.MockSystemReader;
 import org.eclipse.jgit.junit.TestRepository;
+import org.eclipse.jgit.lib.Config;
 import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.util.SystemReader;
@@ -43,6 +44,7 @@ import org.junit.Before;
 public class ServletTest {
   protected TestRepository<DfsRepository> repo;
   protected GitilesServlet servlet;
+  private Config config;
 
   @Before
   public void setUp() throws Exception {
@@ -50,7 +52,11 @@ public class ServletTest {
     SystemReader.setInstance(mockSystemReader);
     DfsRepository r = new InMemoryRepository(new DfsRepositoryDescription("repo"));
     repo = new TestRepository<>(r, new RevWalk(r), mockSystemReader);
-    servlet = TestGitilesServlet.create(repo);
+    if (config == null) {
+      servlet = TestGitilesServlet.create(repo);
+    } else {
+      servlet = TestGitilesServlet.create(repo, new GitwebRedirectFilter(), config);
+    }
   }
 
   @After
@@ -147,6 +153,10 @@ public class ServletTest {
   protected String currentTimeFormatted() {
     PersonIdent p = new PersonIdent(repo.getRepository());
     return new DateFormatter(Optional.empty(), DateFormatter.Format.ISO).format(p);
+  }
+
+  protected void overrideConfig(Config config) {
+    this.config = config;
   }
 
   protected void assertNotFound(String path, String queryString) throws Exception {

--- a/javatests/com/google/gitiles/TestGitilesAccess.java
+++ b/javatests/com/google/gitiles/TestGitilesAccess.java
@@ -29,9 +29,15 @@ import org.eclipse.jgit.lib.Config;
 /** Gitiles access for testing. */
 public class TestGitilesAccess implements GitilesAccess.Factory {
   private final DfsRepository repo;
+  private final Config config;
 
   public TestGitilesAccess(DfsRepository repo) {
+    this(repo, createDefaultConfig());
+  }
+
+  public TestGitilesAccess(DfsRepository repo, Config config) {
     this.repo = checkNotNull(repo);
+    this.config = config;
   }
 
   @Override
@@ -77,15 +83,19 @@ public class TestGitilesAccess implements GitilesAccess.Factory {
 
       @Override
       public Config getConfig() {
-        Config config = new Config();
-        config.setBoolean("markdown", null, "blocknote", true);
-        config.setBoolean("markdown", null, "multicolumn", true);
-        config.setBoolean("markdown", null, "namedanchor", true);
-        config.setBoolean("markdown", null, "smartquote", true);
-        config.setStringList(
-            "gitiles", null, "allowOriginRegex", ImmutableList.of("http://localhost"));
-        return config;
+        return new Config(config);
       }
     };
+  }
+
+  public static Config createDefaultConfig() {
+    Config defaultConfig = new Config();
+    defaultConfig.setBoolean("markdown", null, "blocknote", true);
+    defaultConfig.setBoolean("markdown", null, "multicolumn", true);
+    defaultConfig.setBoolean("markdown", null, "namedanchor", true);
+    defaultConfig.setBoolean("markdown", null, "smartquote", true);
+    defaultConfig.setStringList(
+        "gitiles", null, "allowOriginRegex", ImmutableList.of("http://localhost"));
+    return defaultConfig;
   }
 }

--- a/javatests/com/google/gitiles/TestGitilesServlet.java
+++ b/javatests/com/google/gitiles/TestGitilesServlet.java
@@ -37,6 +37,12 @@ public class TestGitilesServlet {
     return create(repo, new GitwebRedirectFilter());
   }
 
+  /** @see #create(TestRepository) */
+  public static GitilesServlet create(
+      final TestRepository<DfsRepository> repo, GitwebRedirectFilter gitwebRedirect)
+      throws ServletException {
+    return create(repo, gitwebRedirect, null);
+  }
   /**
    * Create a servlet backed by a single test repository.
    *
@@ -48,19 +54,26 @@ public class TestGitilesServlet {
    *
    * @param repo the test repo backing the servlet.
    * @param gitwebRedirect optional redirect filter for gitweb URLs.
+   * @param config optional custom gitiles config
    * @return a servlet.
    */
   public static GitilesServlet create(
-      final TestRepository<DfsRepository> repo, GitwebRedirectFilter gitwebRedirect)
+      final TestRepository<DfsRepository> repo, GitwebRedirectFilter gitwebRedirect, Config config)
       throws ServletException {
     final String repoName = repo.getRepository().getDescription().getRepositoryName();
+
+    GitilesAccess.Factory accessFactory =
+        (config == null)
+            ? new TestGitilesAccess(repo.getRepository())
+            : new TestGitilesAccess(repo.getRepository(), config);
+
     GitilesServlet servlet =
         new GitilesServlet(
             new Config(),
             new DefaultRenderer(
                 GitilesServlet.STATIC_PREFIX, ImmutableList.<URL>of(), repoName + " test site"),
             TestGitilesUrls.URLS,
-            new TestGitilesAccess(repo.getRepository()),
+            accessFactory,
             new RepositoryResolver<HttpServletRequest>() {
               @Override
               public Repository open(HttpServletRequest req, String name)

--- a/javatests/com/google/gitiles/doc/SubNavbarServletTest.java
+++ b/javatests/com/google/gitiles/doc/SubNavbarServletTest.java
@@ -1,0 +1,77 @@
+// Copyright (C) 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gitiles.doc;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.gitiles.TestGitilesAccess;
+import org.eclipse.jgit.lib.Config;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for Subnavbar extending DocServletTest for regressions. */
+@RunWith(JUnit4.class)
+public class SubNavbarServletTest extends DocServletTest {
+  @Override
+  public void setUp() throws Exception {
+    Config subNavbarConfig = TestGitilesAccess.createDefaultConfig();
+    subNavbarConfig.setBoolean("markdown", null, "subnavbar", true);
+    overrideConfig(subNavbarConfig);
+    super.setUp();
+  }
+
+  @Test
+  public void simpleSubNavbar() throws Exception {
+    String rootNavbar =
+        "# Site Title\n" + "\n" + "* [Home](index.md)\n" + "* [README](README.md)\n";
+    String subNavbar =
+        "# Subdir Title\n" + "\n" + "* [Sub Home](index.md)\n" + "* [Sub README](README.md)\n";
+    repo.branch("master")
+        .commit()
+        .add("README.md", "# page\n\nof information.")
+        .add("navbar.md", rootNavbar)
+        .add("subdir/README.md", "# subdir page\n\nof information.")
+        .add("subdir/navbar.md", subNavbar)
+        .create();
+
+    String rootReadmeHtml = buildHtml("/repo/+doc/master/README.md");
+    assertThat(rootReadmeHtml).contains("<title>Site Title - page</title>");
+
+    assertThat(rootReadmeHtml).contains("<span class=\"Header-anchorTitle\">Site Title</span>");
+    assertThat(rootReadmeHtml).contains("<li><a href=\"/b/repo/+/master/index.md\">Home</a></li>");
+    assertThat(rootReadmeHtml)
+        .contains("<li><a href=\"/b/repo/+/master/README.md\">README</a></li>");
+    assertThat(rootReadmeHtml)
+        .contains("<h1><a class=\"h\" name=\"page\" href=\"#page\"><span></span></a>page</h1>");
+
+    String subdirReadmeHtml = buildHtml("/repo/+doc/master/subdir/README.md");
+    assertThat(subdirReadmeHtml).contains("<title>Subdir Title - subdir page</title>");
+
+    assertThat(subdirReadmeHtml).contains("<span class=\"Header-anchorTitle\">Subdir Title</span>");
+    assertThat(subdirReadmeHtml)
+        .contains("<li><a href=\"/b/repo/+/master/subdir/index.md\">Sub Home</a></li>");
+    assertThat(subdirReadmeHtml)
+        .contains("<li><a href=\"/b/repo/+/master/subdir/README.md\">Sub README</a></li>");
+    assertThat(subdirReadmeHtml)
+        .contains(
+            "<h1><a class=\"h\" name=\"subdir-page\" href=\"#subdir-page\"><span></span>"
+                + "</a>subdir page</h1>");
+    assertThat(subdirReadmeHtml)
+        .doesNotContain("<li><a href=\"/b/repo/+/master/index.md\">Home</a></li>");
+    assertThat(subdirReadmeHtml)
+        .doesNotContain("<li><a href=\"/b/repo/+/master/README.md\">README</a></li>");
+  }
+}


### PR DESCRIPTION
This change allows subdirectories to specify their own navbars
only when the subnavbar markdown config is specified.

Resolves #148.