### PR TITLE
SVG support in markdown output

### DIFF
--- a/java/com/google/gitiles/doc/ImageLoader.java
+++ b/java/com/google/gitiles/doc/ImageLoader.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
 class ImageLoader {
   private static final Logger log = LoggerFactory.getLogger(ImageLoader.class);
   private static final ImmutableSet<String> ALLOWED_TYPES =
-      ImmutableSet.of("image/gif", "image/jpeg", "image/png");
+      ImmutableSet.of("image/gif", "image/jpeg", "image/png", "image/svg+xml");
 
   private final ObjectReader reader;
   private final GitilesView view;

--- a/java/com/google/gitiles/doc/html/HtmlBuilder.java
+++ b/java/com/google/gitiles/doc/html/HtmlBuilder.java
@@ -111,7 +111,8 @@ public abstract class HtmlBuilder {
 
   /** Check if URL is valid for {@code <img src="data:image/*;base64,...">}. */
   public static boolean isImageDataUri(String url) {
-    return IMAGE_DATA.getValueFilter().matcher(url).find();
+    return IMAGE_DATA.getValueFilter().matcher(url).find() ||
+        url.startsWith("data:image/svg+xml;base64");
   }
 
   public static boolean isValidGitUri(String val) {


### PR DESCRIPTION
Add image/svg+xml to the list of allowed mimetypes in ImageLoader, and
also relax a check in HtmlBuilder because FilterImageDataUri from
com.google.template.soy.shared.internal.EscapingConventions does not
have svg on the allowed list, and it was rejecting the image data.

This is mostly a local hack I'm pushing for reference since the question of svg support pops up from time to time.